### PR TITLE
pyopengl 3.1.9

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,37 +1,44 @@
-{% set version = "3.1.1a1" %}
-
+{% set name = "pyopengl" %}
+{% set version = "3.1.9" %}
 package:
-  name: pyopengl
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: PyOpenGL-{{ version }}.tar.gz
-  url: https://pypi.python.org/packages/source/P/PyOpenGL/PyOpenGL-{{ version }}.tar.gz
-  sha256: c96d909b359abe3271b746bacf7e6ba52935141e2406a8f90231e4e44dfa4075
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/pyopengl-{{ version }}.tar.gz
+  sha256: 28ebd82c5f4491a418aeca9672dffb3adbe7d33b39eada4548a5b4e8c03f60c8
 
 build:
-  script: python setup.py install --single-version-externally-managed --record record.txt
   number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - setuptools
     - python
-
+    - pip
+    - setuptools >=42.0
+    - wheel
   run:
     - python
 
 test:
   imports:
     - OpenGL.GL
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
-  home: http://pyopengl.sourceforge.net
-  license: BSD-like
+  home: https://mcfletch.github.io/pyopengl/
+  license: LicenseRef-pyopengl
+  license_family: Other
   license_file: license.txt
   summary: Standard OpenGL bindings for Python
-  doc_url: http://pyopengl.sourceforge.net/documentation/index.html
-  doc_source_url: https://sourceforge.net/projects/pyopengl/
+  description: |
+    PyOpenGL is the most common cross platform Python binding to OpenGL and related APIs.
+    The binding is created using the standard ctypes library, and is provided under a liberal BSD-style Open-Source license.
+  doc_url: https://mcfletch.github.io/pyopengl/documentation/index.html
   dev_url: https://github.com/mcfletch/pyopengl
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - pip
     - setuptools >=42.0
     - wheel
+    - freeglut  # [win]
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,10 @@ source:
 
 build:
   number: 0
+  # libgle (GLE) isn't available on win on the main channel, the upstream provides precompiled DLLs for Windows,
+  # see https://github.com/mcfletch/pyopengl/tree/master/OpenGL/DLLS,
+  # but it's not secure to include them.
+  skip: true  # [win]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -18,7 +22,6 @@ requirements:
     - pip
     - setuptools >=42.0
     - wheel
-    - freeglut  # [win]
   run:
     - python
 


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-4807](https://anaconda.atlassian.net/browse/PKG-4807) 
- [Upstream repository](https://github.com/mcfletch/pyopengl)
- pypi inspector: https://inspector.pypi.io/project/pyopengl/3.1.9/packages/c0/42/71080db298df3ddb7e3090bfea8fd7c300894d8b10954c22f8719bd434eb/pyopengl-3.1.9.tar.gz/
- License: https://inspector.pypi.io/project/pyopengl/3.1.9/packages/c0/42/71080db298df3ddb7e3090bfea8fd7c300894d8b10954c22f8719bd434eb/pyopengl-3.1.9.tar.gz/pyopengl-3.1.9/license.txt
- Requirements:
  - https://inspector.pypi.io/project/pyopengl/3.1.9/packages/c0/42/71080db298df3ddb7e3090bfea8fd7c300894d8b10954c22f8719bd434eb/pyopengl-3.1.9.tar.gz/pyopengl-3.1.9/pyproject.toml
  - https://inspector.pypi.io/project/pyopengl/3.1.9/packages/c0/42/71080db298df3ddb7e3090bfea8fd7c300894d8b10954c22f8719bd434eb/pyopengl-3.1.9.tar.gz/pyopengl-3.1.9/setup.py

### Explanation of changes:

- Skip `win` because pyopengl repacks freeglut and GLE on Windows.

### Notes:

-

[PKG-4807]: https://anaconda.atlassian.net/browse/PKG-4807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ